### PR TITLE
fix(upload): remove artificial signMessage timeout

### DIFF
--- a/src/app/components/FileUploadUtils.ts
+++ b/src/app/components/FileUploadUtils.ts
@@ -364,39 +364,7 @@ export const handleFileUpload = async (params: FileUploadParams): Promise<string
 
     const messageToSign = `${processedFile.name}:${postageBatchId}`;
 
-    // Helper function to sign with timeout
-    const signWithTimeout = async (message: string, timeoutMs: number = 5000): Promise<string> => {
-      return new Promise(async (resolve, reject) => {
-        const timeout = setTimeout(() => {
-          reject(new Error('WALLET_UNLOCK_REQUIRED'));
-        }, timeoutMs);
-
-        try {
-          const signature = await walletClient.signMessage({ message });
-          clearTimeout(timeout);
-          resolve(signature);
-        } catch (error) {
-          clearTimeout(timeout);
-          reject(error);
-        }
-      });
-    };
-
-    let signedMessage: string;
-    try {
-      signedMessage = await signWithTimeout(messageToSign);
-    } catch (error: any) {
-      if (error.message === 'WALLET_UNLOCK_REQUIRED') {
-        setStatusMessage({
-          step: 'Wallet Locked',
-          message: 'Please unlock your wallet to sign the message',
-          error: 'Your wallet appears to be locked. Please unlock your wallet and try again.',
-          isError: true,
-        });
-        throw new Error('Wallet unlock required - please unlock your wallet and try again');
-      }
-      throw error;
-    }
+    const signedMessage = await walletClient.signMessage({ message: messageToSign });
 
     // Determine Content-Type with fallback for unsupported file types
     let contentType: string;
@@ -682,41 +650,7 @@ export const handleMultiFileUpload = async (
       // Only sign message for the very first file
       let signedMessage = '';
       if (fileIndex === 0) {
-        // Helper function to sign with timeout
-        const signWithTimeout = async (
-          message: string,
-          timeoutMs: number = 5000
-        ): Promise<string> => {
-          return new Promise(async (resolve, reject) => {
-            const timeout = setTimeout(() => {
-              reject(new Error('WALLET_UNLOCK_REQUIRED'));
-            }, timeoutMs);
-
-            try {
-              const signature = await walletClient.signMessage({ message });
-              clearTimeout(timeout);
-              resolve(signature);
-            } catch (error) {
-              clearTimeout(timeout);
-              reject(error);
-            }
-          });
-        };
-
-        try {
-          signedMessage = await signWithTimeout(messageToSign);
-        } catch (error: any) {
-          if (error.message === 'WALLET_UNLOCK_REQUIRED') {
-            setStatusMessage({
-              step: 'Wallet Locked',
-              message: 'Please unlock your wallet to sign the message',
-              error: 'Your wallet appears to be locked. Please unlock your wallet and try again.',
-              isError: true,
-            });
-            throw new Error('Wallet unlock required - please unlock your wallet and try again');
-          }
-          throw error;
-        }
+        signedMessage = await walletClient.signMessage({ message: messageToSign });
       }
 
       // Determine Content-Type with fallback for unsupported file types
@@ -766,41 +700,7 @@ export const handleMultiFileUpload = async (
             `❌ File ${fileIndex + 1}: No session token available, falling back to signature (this should not happen)`
           );
 
-          // Helper function to sign with timeout
-          const signWithTimeout = async (
-            message: string,
-            timeoutMs: number = 5000
-          ): Promise<string> => {
-            return new Promise(async (resolve, reject) => {
-              const timeout = setTimeout(() => {
-                reject(new Error('WALLET_UNLOCK_REQUIRED'));
-              }, timeoutMs);
-
-              try {
-                const signature = await walletClient.signMessage({ message });
-                clearTimeout(timeout);
-                resolve(signature);
-              } catch (error) {
-                clearTimeout(timeout);
-                reject(error);
-              }
-            });
-          };
-
-          try {
-            signedMessage = await signWithTimeout(messageToSign);
-          } catch (error: any) {
-            if (error.message === 'WALLET_UNLOCK_REQUIRED') {
-              setStatusMessage({
-                step: 'Wallet Locked',
-                message: 'Please unlock your wallet to sign the message',
-                error: 'Your wallet appears to be locked. Please unlock your wallet and try again.',
-                isError: true,
-              });
-              throw new Error('Wallet unlock required - please unlock your wallet and try again');
-            }
-            throw error;
-          }
+          signedMessage = await walletClient.signMessage({ message: messageToSign });
           baseHeaders['x-upload-signed-message'] = signedMessage;
         }
       }

--- a/src/app/components/NFTCollectionProcessor.ts
+++ b/src/app/components/NFTCollectionProcessor.ts
@@ -212,33 +212,7 @@ const uploadFile = async (
   // Sign message for upload authorization
   const messageToSign = `${file.name}:${postageBatchId}`;
 
-  // Helper function to sign with timeout
-  const signWithTimeout = async (message: string, timeoutMs: number = 5000): Promise<string> => {
-    return new Promise(async (resolve, reject) => {
-      const timeout = setTimeout(() => {
-        reject(new Error('WALLET_UNLOCK_REQUIRED'));
-      }, timeoutMs);
-
-      try {
-        const signature = await walletClient.signMessage({ message });
-        clearTimeout(timeout);
-        resolve(signature);
-      } catch (error) {
-        clearTimeout(timeout);
-        reject(error);
-      }
-    });
-  };
-
-  let signedMessage: string;
-  try {
-    signedMessage = await signWithTimeout(messageToSign);
-  } catch (error: any) {
-    if (error.message === 'WALLET_UNLOCK_REQUIRED') {
-      throw new Error('Wallet unlock required - please unlock your wallet and try again');
-    }
-    throw error;
-  }
+  const signedMessage = await walletClient.signMessage({ message: messageToSign });
 
   // Setup headers
   const headers: Record<string, string> = {


### PR DESCRIPTION
The client-side timer cut off slow confirmations and showed a misleading wallet-unlock error. signMessage already stays pending until the user acts or the wallet errors; rely on that behavior.