### PR TITLE
ci: run swarm-upload on self-hosted runners

### DIFF
--- a/.github/workflows/swarm_upload.yml
+++ b/.github/workflows/swarm_upload.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, bee]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Switch this workflow to the org's self-hosted runners. Existing triggers unchanged.