### PR TITLE
fix(proxy): avoid serving dead sockets after upstream restart

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache tini # Install tini
 WORKDIR /app
 COPY . .
 
-RUN npm install express http-proxy-middleware viem cors dotenv
+RUN npm install express http-proxy-middleware viem cors dotenv agentkeepalive
 USER nobody
 EXPOSE ${PORT}
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -5,10 +5,26 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
 const { createPublicClient, http } = require('viem');
 const { gnosis } = require('viem/chains');
 const crypto = require('crypto');
+const HttpAgent = require('agentkeepalive');
+const { HttpsAgent } = require('agentkeepalive');
 
 // Add this near the top with other environment variables
 const PORT = process.env.PORT || 3333;
 const PROXY_TARGET = process.env.PROXY_TARGET || 'http://localhost:1633';
+
+// Bounded keep-alive agent for the upstream bee node. Without an explicit
+// agent, http-proxy-middleware v4 (via httpxy) uses a singleton keep-alive
+// pool whose sockets survive an upstream restart and serve dead connections
+// until the proxy process is restarted. socketActiveTTL caps socket lifetime
+// so the pool drains on its own after a bee restart.
+const AgentCtor = PROXY_TARGET.startsWith('https:') ? HttpsAgent : HttpAgent;
+const upstreamAgent = new AgentCtor({
+  keepAlive: true,
+  maxSockets: 256,
+  maxFreeSockets: 64,
+  freeSocketTimeout: 30_000,
+  socketActiveTTL: 60_000,
+});
 const REGISTRY_ADDRESS =
   process.env.REGISTRY_ADDRESS || '0x5EBfBeFB1E88391eFb022d5d33302f50a46bF4f3';
 
@@ -233,6 +249,7 @@ app.use((req, res, next) => {
 
 const proxy = createProxyMiddleware({
   target: PROXY_TARGET,
+  agent: upstreamAgent,
   changeOrigin: true,
   pathRewrite: null,
   secure: false,


### PR DESCRIPTION
## Problem

When the upstream bee node restarts (e.g. a pod restart behind a stable service IP), beeport-proxy keeps serving dead TCP sockets and requests fail until the proxy process itself is restarted.

## Root cause

`http-proxy-middleware@4` swapped its underlying engine to `httpxy`. When no `agent` option is passed, `httpxy` falls back to a module-level singleton keep-alive Agent (`keepAlive: true, maxSockets: 256, maxFreeSockets: 64`) — see `httpxy/src/_utils.ts:117-127`. Pooled sockets survive the upstream restart but point at the old endpoint; the pool keeps handing them out for new requests until the OS TCP retransmit eventually times out, or until the process restarts and the pool is recreated empty.

The current `backend/index.js` does not pass `agent` to `createProxyMiddleware`, so every deployment inherits this behavior.

## Fix

Pass an explicit `agentkeepalive` Agent with bounded socket lifetime. `socketActiveTTL: 60_000` hard-kills any socket older than 60s, so the pool fully rotates within a minute of an upstream restart and dead sockets stop being reused. The other parameters match `httpxy`'s defaults so steady-state capacity is unchanged.

`HttpAgent` / `HttpsAgent` is selected from `PROXY_TARGET`'s protocol so HTTPS upstreams work the same way.

## Test plan

- [ ] Build the container; verify it boots and proxies normally.
- [ ] Restart the upstream backend mid-traffic; confirm uploads recover within ~60s without restarting the proxy.
- [ ] WebSocket upgrades still work (`ws: true`) — httpxy already bypasses the agent for `Connection: upgrade`, so the explicit agent doesn't affect that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)