### PR TITLE
fix/Add erasure coding support for multi-file uploads

### DIFF
--- a/src/app/components/FileUploadUtils.ts
+++ b/src/app/components/FileUploadUtils.ts
@@ -90,6 +90,7 @@ export interface MultiFileUploadParams {
   beeApiUrl: string;
   serveUncompressed: boolean;
   isWebpageUpload: boolean;
+  redundancyLevel?: number;
   setUploadProgress: (progress: number) => void;
   setStatusMessage: (status: ExecutionStatus) => void;
   setIsDistributing: (isDistributing: boolean) => void;
@@ -584,6 +585,7 @@ export const handleMultiFileUpload = async (
     beeApiUrl,
     serveUncompressed,
     isWebpageUpload,
+    redundancyLevel = 0,
     setUploadProgress,
     setStatusMessage,
     setIsDistributing,
@@ -684,8 +686,9 @@ export const handleMultiFileUpload = async (
         baseHeaders['Swarm-Error-Document'] = 'error.html';
       }
 
-      // Add erasure coding redundancy level if specified (for multi-file uploads, use level 0 by default)
-      // Note: Multi-file uploads don't currently support redundancy level selection
+      if (redundancyLevel > 0) {
+        baseHeaders['swarm-redundancy-level'] = redundancyLevel.toString();
+      }
 
       if (!isLocalhost) {
         // For multi-file uploads, add session-related headers

--- a/src/app/components/SwapComponent.tsx
+++ b/src/app/components/SwapComponent.tsx
@@ -1115,6 +1115,7 @@ const SwapComponent: React.FC = () => {
         beeApiUrl,
         serveUncompressed,
         isWebpageUpload,
+        redundancyLevel,
         setUploadProgress,
         setStatusMessage,
         setIsDistributing,
@@ -1796,7 +1797,8 @@ const SwapComponent: React.FC = () => {
                           </div>
                         )}
 
-                        {!isMultipleFiles && selectedFile && (
+                        {((!isMultipleFiles && selectedFile) ||
+                          (isMultipleFiles && selectedFiles.length > 0)) && (
                           <div className={styles.dropdownWrapper}>
                             <label className={styles.dropdownLabel}>
                               Erasure Coding


### PR DESCRIPTION
## Summary
- Show the Erasure Coding dropdown when uploading multiple files separately
- Pass the selected redundancy level through the multi-file upload flow
- Send `swarm-redundancy-level` header for each file in a multi-file upload batch

## Test plan
- [ ] Select "Multiple files separately" and choose 2+ files — Erasure Coding dropdown should appear
- [ ] Upload with erasure coding level > 0 and verify each file gets its own hash with redundancy applied
- [ ] Confirm single-file upload erasure coding still works as before
- [ ] Upload with level 0 (default) and confirm no `swarm-redundancy-level` header is sent