### PR TITLE
Fix stale isWebpageUpload flag on non-archive uploads

### DIFF
--- a/src/app/components/FileUploadUtils.ts
+++ b/src/app/components/FileUploadUtils.ts
@@ -340,8 +340,9 @@ export const handleFileUpload = async (params: FileUploadParams): Promise<string
     const isTarArchive =
       selectedFile.type === 'application/x-tar' || selectedFile.name.toLowerCase().endsWith('.tar');
 
-    // Process TAR files - always upload as website with index.html check
-    let shouldUploadAsWebsite = isWebpageUpload;
+    // Only apply webpage upload to archive files; ignore stale checkbox state for regular files
+    const isEligibleForWebpageOption = isTarArchive || isArchive;
+    let shouldUploadAsWebsite = isEligibleForWebpageOption ? isWebpageUpload : false;
     let hasIndexFile = false;
 
     if (isTarArchive) {
@@ -615,7 +616,7 @@ export const handleMultiFileUpload = async (
     const maxRetries = UPLOAD_RETRY_CONFIG.maxRetries;
 
     // Initialize website flags outside try block so they're available in catch
-    let shouldUploadAsWebsite = isWebpageUpload;
+    let shouldUploadAsWebsite = false;
     let hasIndexFile = false;
 
     try {
@@ -629,6 +630,9 @@ export const handleMultiFileUpload = async (
 
       const isTarArchive =
         file.type === 'application/x-tar' || file.name.toLowerCase().endsWith('.tar');
+
+      const isEligibleForWebpageOption = isTarArchive || isArchive;
+      shouldUploadAsWebsite = isEligibleForWebpageOption ? isWebpageUpload : false;
 
       if (isTarArchive) {
         const tarResult = await processTarFile({

--- a/src/app/components/SwapComponent.tsx
+++ b/src/app/components/SwapComponent.tsx
@@ -1595,6 +1595,7 @@ const SwapComponent: React.FC = () => {
                               setSelectedFile(null);
                               setSelectedFiles([]);
                               setIsFolderUpload(false);
+                              setIsWebpageUpload(false);
                             }}
                             className={styles.checkbox}
                             disabled={uploadStep === 'uploading'}
@@ -1668,16 +1669,19 @@ const SwapComponent: React.FC = () => {
                                 const files = Array.from(e.target.files || []);
                                 setSelectedFiles(files);
                                 setSelectedFile(null);
+                                setIsWebpageUpload(false);
                               } else {
                                 const file = e.target.files?.[0] || null;
                                 setSelectedFile(file);
                                 setSelectedFiles([]);
-                                setIsTarFile(
-                                  (file?.name.toLowerCase().endsWith('.tar') ||
-                                    file?.name.toLowerCase().endsWith('.zip') ||
-                                    file?.name.toLowerCase().endsWith('.gz')) ??
-                                    false
-                                );
+                                const isArchiveFile =
+                                  file?.name.toLowerCase().endsWith('.tar') ||
+                                  file?.name.toLowerCase().endsWith('.zip') ||
+                                  file?.name.toLowerCase().endsWith('.gz');
+                                setIsTarFile(isArchiveFile ?? false);
+                                if (!isArchiveFile) {
+                                  setIsWebpageUpload(false);
+                                }
                               }
                             }}
                             className={styles.fileInput}


### PR DESCRIPTION
## Summary
- Reset `isWebpageUpload` when switching to multiple-file mode or selecting non-archive files
- Only apply webpage upload flag to archive files (`.tar`, `.zip`, `.gz`) in upload logic, preventing regular files like PNGs from inheriting a stale checkbox state

## Test plan
- [ ] Upload a `.tar` with "Upload as webpage" enabled, then switch to a PNG without closing the overlay — verify PNG uploads with `isWebpageUpload: false`
- [ ] Enable webpage upload on an archive, then switch to multiple files mode and upload PNGs — verify history records show `isWebpageUpload: false`
- [ ] Confirm archive uploads with webpage option still work as before